### PR TITLE
Use "public domain-equivalent" instead of "public"

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
 		<p>This site contains all PenguinMod sounds, costumes or other items that are added to the library.</p>
 		<p>To add an item to one of these libraries, feel free to contribute to the <a href="https://github.com/PenguinMod/PenguinMod-ObjectLibraries">GitHub repository.</a></p>
 		<br>
-		<p><b>Note: All new sounds & costumes MUST be Public Domain (creative commons 0 or other public licenses) or MIT licensed. There are no exceptions.</b></p>
+		<p><b>Note: All new sounds & costumes MUST be Public Domain (creative commons 0 or other public domain-equivalent license) or MIT licensed. There are no exceptions.</b></p>
 		<p>If you make the content yourself and upload it here, note that your content can be used, sold and modified without your permission required or credits required.</p>
 		<br>
 		<p>Please check your sources to confirm the content is allowed on PenguinMod. For example, PenguinMod gets sounds from <a href="https://freesound.org">freesound.org</a> under the Creative Commons 0 License.</p>

--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
 		<p>This site contains all PenguinMod sounds, costumes or other items that are added to the library.</p>
 		<p>To add an item to one of these libraries, feel free to contribute to the <a href="https://github.com/PenguinMod/PenguinMod-ObjectLibraries">GitHub repository.</a></p>
 		<br>
-		<p><b>Note: All new sounds & costumes MUST be Public Domain (creative commons 0 or other public domain-equivalent license) or MIT licensed. There are no exceptions.</b></p>
+		<p><b>Note: All new sounds & costumes MUST be Public Domain (creative commons 0 or other public domain-equivalent licenses) or MIT licensed. There are no exceptions.</b></p>
 		<p>If you make the content yourself and upload it here, note that your content can be used, sold and modified without your permission required or credits required.</p>
 		<br>
 		<p>Please check your sources to confirm the content is allowed on PenguinMod. For example, PenguinMod gets sounds from <a href="https://freesound.org">freesound.org</a> under the Creative Commons 0 License.</p>


### PR DESCRIPTION
Public licenses are not actually the same thing as public domain-equivalent licenses. A public license is a license that allows for more general public usage, MIT, GPL and MPL are examples of public licenses.

Public domain-equivalent licenses, on the other hand are licenses that provide rights equivalent to the US' public domain. So if they allow for fully free distribution, commercial usage, modification, and relicensing without needing to attribution the original authors of the work. IE, they allow for the same things that they would allow for as if they were in the public domain.